### PR TITLE
op3: Stop using legacy open for cameras

### DIFF
--- a/overlay/packages/apps/Snap/res/values/config.xml
+++ b/overlay/packages/apps/Snap/res/values/config.xml
@@ -26,4 +26,10 @@
         <item>sports</item>
     </string-array>
 
+    <!-- Opens back camera using openLegacy() and forces api v1 -->
+    <bool name="back_camera_open_legacy">false</bool>
+
+    <!-- Opens front camera using openLegacy() and forces api v1 -->
+    <bool name="front_camera_open_legacy">false</bool>
+
 </resources>


### PR DESCRIPTION
 * Otherwise Snap won't use HAL3 api.

Change-Id: Iee6bdc5199974f3f57919d453132df06fbad5681