### PR TITLE
restart cam preview after picture taken

### DIFF
--- a/overlay/packages/apps/Snap/res/values/config.xml
+++ b/overlay/packages/apps/Snap/res/values/config.xml
@@ -32,4 +32,10 @@
     <!-- Opens front camera using openLegacy() and forces api v1 -->
     <bool name="front_camera_open_legacy">false</bool>
 
+    <!-- Restart preview for back camera onPictureTaken -->
+    <bool name="back_camera_restart_preview_onPictureTaken">true</bool>
+
+    <!-- Restart preview for front camera onPictureTaken -->
+    <bool name="front_camera_restart_preview_onPictureTaken">true</bool>
+
 </resources>


### PR DESCRIPTION
* this prevents the camera from freezing after first picture taken

Change-Id: I97a0fdeeb601d4049f92a6ef540aca721a918ac6